### PR TITLE
Database catalog_product_entity.row_id isn't always the same as catalog_product_entity.entity_id

### DIFF
--- a/src/Model/Write/EavIterator.php
+++ b/src/Model/Write/EavIterator.php
@@ -310,7 +310,7 @@ class EavIterator implements IteratorAggregate
             ->from(['attribute_table' => $table], [])
             ->join(['main_table' => $this->getEntityType()->getEntityTable()], 'attribute_table.row_id = main_table.row_id', [])
             ->columns([
-                'entity_id' => 'main_table.row_id',
+                'entity_id' => 'main_table.entity_id',
                 'store_id' => 'attribute_table.store_id',
                 'attribute_id' => 'attribute_table.attribute_id',
                 'value' => 'attribute_table.value'


### PR DESCRIPTION
The query was build using row_id as entity_id, but this is causing wrong results because row_id and entity_id aren't always the same.

![screen shot 2017-11-08 at 14 41 42](https://user-images.githubusercontent.com/9214557/32552065-f982d16c-c492-11e7-9b5b-28e2f54c0b00.png)

Query should use column entity_id as entity_id.