### PR TITLE
Fix fatal error when magento has more then 1000 products

### DIFF
--- a/src/Model/Write/Products/Iterator.php
+++ b/src/Model/Write/Products/Iterator.php
@@ -86,7 +86,7 @@ class Iterator extends EavIterator
                 foreach ($this->processBatch($batch) as $processedEntity) {
                     yield $processedEntity;
                 }
-                $batch = $this->collectionFactory->create();
+                $batch = $this->collectionFactory->create(['storeId' => $this->storeId]);
             }
         }
 


### PR DESCRIPTION
The product collection isn't correctly initialized when Magento has more products then the batch allows.

This fixes issue https://github.com/EmicoEcommerce/Magento2TweakwiseExport/issues/36