### PR TITLE
Add all attributes to export

### DIFF
--- a/src/Model/Write/Products/ExportEntity.php
+++ b/src/Model/Write/Products/ExportEntity.php
@@ -108,16 +108,19 @@ class ExportEntity
                     break;
                 case 'status';
                     $this->setStatus((int) $value);
+                    $this->addAttribute($key, (int) $value);
                     break;
                 case 'visibility';
                     $this->setVisibility((int) $value);
-                    $this->addAttribute($key, $value);
+                    $this->addAttribute($key, (int) $value);
                     break;
                 case 'name';
                     $this->setName((string) $value);
+                    $this->addAttribute($key, (string) $value);
                     break;
                 case 'price';
                     $this->setPrice((float) $value);
+                    $this->addAttribute($key, (float) $value);
                     break;
                 default:
                     $this->addAttribute($key, $value);


### PR DESCRIPTION
After an update we ran into a problem that price was no langer in the `attributes` list of an item in the XML feed. Now we couldn't filter and sort by price anymore because this attribute was empty. 

Just had a talk with Marlou Drouven from Tweakwise. She told me that it's better to also have price in the attributes list. This Pull Request adds `price`, `visibility`, `status` and `name`. to the attributes list.