### PR TITLE
getSource will always return instanceof SourceInterface, instead chec…

### DIFF
--- a/src/Model/Write/Products.php
+++ b/src/Model/Write/Products.php
@@ -295,8 +295,7 @@ class Products implements WriterInterface
             $values = $this->explodeValues($values);
         }
 
-        $source = $attribute->getSource();
-        if (!$source instanceof SourceInterface) {
+        if (!$attribute->getSourceModel()) {
             return $values;
         }
 


### PR DESCRIPTION
All values will be processed by the method `\Emico\TweakwiseExport\Model\Write\Products::normalizeAttributeValue`. This method contains a check `$attribute->getSource() instanceof SourceInterface`. This will always return true. When a attribute is text and doesn't contain any options this method will return a value of NULL instead of the original value.

Fix: getSource will always return instanceof SourceInterface, instead check if attribute hasSourceModel