### PR TITLE
Fixes an edge case problem with a third party module, which caused th…

### DIFF
--- a/src/Controller/Feed/Export.php
+++ b/src/Controller/Feed/Export.php
@@ -66,7 +66,9 @@ class Export extends Action
             throw new NotFoundException(__('Page not found.'));
         }
 
+        $feedContent = (new FeedContent($this->export, $this->log))->__toString();
+
         $response->setHeader('Content-Type', 'text/xml');
-        $response->setContent(new FeedContent($this->export, $this->log));
+        $response->setContent($feedContent);
     }
 }


### PR DESCRIPTION
…e xml to be outputted twice in the export.

Hi!

This is a small fix, which we needed for a third party module (Amasty_SeoToolKit).
This module has an observer watching the event `controller_front_send_response_before` and does some manipulation on the content which is outputted to the browser.

Since the content which was added to the output in the TweakwiseExport module was an object instead of a string. And since what that third party module was doing with the content, caused the xml to be outputted twice. Which caused the Tweakwise servers to not being able to read the file because it wasn't valid xml.

Fix is to explicitly call the `__toString` method on the object before passing it in the content of the response. We've opted to put it in an extra variable since it makes it a bit more easier to read.

Thanks to @duckchip for the investigation!
