### PR TITLE
Don't output feed to output stream directly in _toString() method but…

### DIFF
--- a/src/App/Response/FeedContent.php
+++ b/src/App/Response/FeedContent.php
@@ -47,8 +47,7 @@ class FeedContent {
      */
     public function __toString()
     {
-        ob_start();
-        $resource = fopen('php://output', 'wb');
+        $resource = fopen('php://memory', 'wb');
         try {
             try {
                 $this->export->getFeed($resource);
@@ -56,10 +55,10 @@ class FeedContent {
                 $this->log->error(sprintf('Failed to get feed due to %s', $e->getMessage()));
             }
         } finally {
+            rewind($resource);
+            $output = \stream_get_contents($resource);
             fclose($resource);
         }
-        $output = ob_get_contents();
-        ob_end_clean();
         return $output;
     }
 }

--- a/src/App/Response/FeedContent.php
+++ b/src/App/Response/FeedContent.php
@@ -43,12 +43,11 @@ class FeedContent {
     }
 
     /**
-     * Also renders feed to output stream
-     *
      * @return string
      */
     public function __toString()
     {
+        ob_start();
         $resource = fopen('php://output', 'wb');
         try {
             try {
@@ -59,7 +58,8 @@ class FeedContent {
         } finally {
             fclose($resource);
         }
-
-        return '';
+        $output = ob_get_contents();
+        ob_end_clean();
+        return $output;
     }
 }


### PR DESCRIPTION
Don't output feed to output stream directly in _toString() method but return the output instead (Fix 'Warning: Cannot modify header information - headers already sent')

Because in some cases Magento already sends headers, just outputting the feed to the output stream causes and "Cannot modify header" error. Plus, now the __toString() function really does what it should to, unless there was a reason to do so (maybe large outputs?)