### PR TITLE
Added check on empty array to prevent Exception on executing max on e…

### DIFF
--- a/src/Model/Write/Products/CollectionDecorator/StockData.php
+++ b/src/Model/Write/Products/CollectionDecorator/StockData.php
@@ -214,6 +214,9 @@ class StockData implements DecoratorInterface
     private function getCombinedStock(ExportEntity $entity, int $storeId): float
     {
         $stockQuantities = $this->getStockQuantities($entity);
+        if (empty($stockQuantities)) {
+            return 0;
+        }
 
         switch ($this->config->getStockCalculation($storeId)) {
             case StockCalculation::OPTION_MAX:


### PR DESCRIPTION
Added check on empty array to prevent Exception on executing max on execuriting a max() or min() on an empty array. This situation occurs when Export out of stock combined product children is set to 0, but Bundles or Configurables have child products that are out of stock. 