### PR TITLE
Fix for Warning: Invalid argument supplied for foreach()

### DIFF
--- a/src/Model/Write/Products/ExportEntity.php
+++ b/src/Model/Write/Products/ExportEntity.php
@@ -391,9 +391,11 @@ class ExportEntity
     public function getExportChildrenIncludeOutOfStock(): array
     {
         $children = [];
-        foreach ($this->children as $child) {
-            if ($child->shouldExport(true)) {
-                $children[] = $child;
+        if (!empty($this->children)) {
+            foreach ($this->children as $child) {
+                if ($child->shouldExport(true)) {
+                    $children[] = $child;
+                }
             }
         }
 


### PR DESCRIPTION
 in Model/Write/Products/ExportEntity.php on line 394 

When executing the 'emico_tweakwise_export' cron task we run into the error as stated above. 
This code-change will prevent this warning.

Please let me know if you have any further questions.