### PR TITLE
Extended check for empty name attribute to the value itself

### DIFF
--- a/src/Model/Write/Products/ExportEntity.php
+++ b/src/Model/Write/Products/ExportEntity.php
@@ -538,6 +538,6 @@ class ExportEntity
      */
     protected function shouldExportByNameAttribute(): bool
     {
-        return !empty($this->attributes['name']);
+        return !(empty($this->attributes['name']) || empty($this->getAttribute('name',false)));
     }
 }


### PR DESCRIPTION
For one of our clients uses an external system which contains lot of empty name values. Therefore I added this extra check which might be useful for more cases with an empty name on storeview level.