### PR TITLE
Fix for when the productId does not exist in the collection of export…

### DIFF
--- a/src/Model/Write/Products/CollectionDecorator/Review.php
+++ b/src/Model/Write/Products/CollectionDecorator/Review.php
@@ -43,19 +43,13 @@ class Review implements DecoratorInterface
         /** @var ProductReviewSummary $review */
         foreach ($reviews as $review) {
             $productId = $review->getProductId();
-
-            $exportEntity = false;
-
             try {
                 $exportEntity = $collection->get($productId);
-            } catch (InvalidArgumentException $e) {}
-
-            if (!$exportEntity) {
+                $exportEntity->addAttribute('review_rating', $review->getAverageRating());
+                $exportEntity->addAttribute('review_count', $review->getReviewCount());
+            } catch (InvalidArgumentException $e) {
                 continue;
             }
-
-            $exportEntity->addAttribute('review_rating', $review->getAverageRating());
-            $exportEntity->addAttribute('review_count', $review->getReviewCount());
         }
     }
 }

--- a/src/Model/Write/Products/CollectionDecorator/Review.php
+++ b/src/Model/Write/Products/CollectionDecorator/Review.php
@@ -6,6 +6,7 @@
 
 namespace Emico\TweakwiseExport\Model\Write\Products\CollectionDecorator;
 
+use Emico\TweakwiseExport\Exception\InvalidArgumentException;
 use Emico\TweakwiseExport\Model\Review\ProductReviewSummary;
 use Emico\TweakwiseExport\Model\Review\ReviewProviderInterface;
 use Emico\TweakwiseExport\Model\Write\Products\Collection;
@@ -42,7 +43,14 @@ class Review implements DecoratorInterface
         /** @var ProductReviewSummary $review */
         foreach ($reviews as $review) {
             $productId = $review->getProductId();
-            if (!$exportEntity = $collection->get($productId)) {
+
+            $exportEntity = false;
+
+            try {
+                $exportEntity = $collection->get($productId);
+            } catch (InvalidArgumentException $e) {}
+
+            if (!$exportEntity) {
                 continue;
             }
 


### PR DESCRIPTION

![error_emico_tweakwise_export](https://user-images.githubusercontent.com/18070887/71619113-1ccc7580-2bc3-11ea-9d19-2ed3faeb3648.png)
… entities.

* This fix fixes the error "Could not find export entity with id {product_id}".

By adding a try catch with argument InvalidArgumentException i can catch these errors. This way the export can still continue even though the entity does not exist.

