### PR TITLE
Fix empty filtered collection throwing error

### DIFF
--- a/src/Model/Write/Products/CollectionDecorator/StockData/StockItemMapProvider.php
+++ b/src/Model/Write/Products/CollectionDecorator/StockData/StockItemMapProvider.php
@@ -59,6 +59,10 @@ class StockItemMapProvider implements StockMapProviderInterface
         }
 
         $entityIds = $collection->getAllIds();
+        
+        if (count($entityIds) === 0) {
+            return [];
+        }
 
         $criteria = $this->criteriaFactory->create();
         $criteria->setProductsFilter([$entityIds]);


### PR DESCRIPTION
Return empty array when filtered collection is empty.

See https://github.com/EmicoEcommerce/Magento2TweakwiseExport/issues/86