### PR TITLE
Make configurable products always have stock if at least one of the children has stock (configurables don't have inventory source items). Also add trait for removing duplicate code

### DIFF
--- a/Model/Write/Products/ExportEntityBundle.php
+++ b/Model/Write/Products/ExportEntityBundle.php
@@ -17,7 +17,7 @@ use Magento\Catalog\Model\Product\Attribute\Source\Status;
 class ExportEntityBundle extends CompositeExportEntity
 {
     /**
-     * @var boolean
+     * @var bool
      */
     protected $isStockCombined;
 

--- a/Model/Write/Products/ExportEntityConfigurable.php
+++ b/Model/Write/Products/ExportEntityConfigurable.php
@@ -7,50 +7,18 @@
 
 namespace Emico\TweakwiseExport\Model\Write\Products;
 
-use Emico\TweakwiseExport\Model\StockItem;
+use Emico\TweakwiseExport\Traits\Stock\HasStockThroughChildren;
 
+/**
+ * Class ExportEntityConfigurable
+ * @package Emico\TweakwiseExport\Model\Write\Products
+ */
 class ExportEntityConfigurable extends CompositeExportEntity
 {
+    use HasStockThroughChildren;
 
     /**
-     * @var
+     * @var bool
      */
     protected $isStockCombined;
-
-    /**
-     * @return StockItem
-     */
-    public function getStockItem(): ?StockItem
-    {
-        if ($this->isStockCombined) {
-            return $this->stockItem;
-        }
-
-        if (!$this->children) {
-            return $this->stockItem;
-        }
-
-        $childQty = [];
-        $childStockStatus = [];
-
-        foreach ($this->getEnabledChildren() as $child) {
-            $childQty[] = $child->getStockItem()->getQty();
-            $childStockStatus[] = $child->getStockItem()->getIsInStock();
-        }
-
-        if (empty($childStockStatus) || empty($childQty)) {
-            $this->isStockCombined = true;
-            return $this->stockItem;
-        }
-
-        $qty = (int) array_sum($childQty);
-        $isInStock = min(max($childStockStatus), $this->stockItem->getIsInStock());
-        $stockItem = new StockItem();
-        $stockItem->setQty($qty);
-        $stockItem->setIsInStock($isInStock);
-
-        $this->stockItem = $stockItem;
-        $this->isStockCombined = true;
-        return $this->stockItem;
-    }
 }

--- a/Model/Write/Products/ExportEntityGrouped.php
+++ b/Model/Write/Products/ExportEntityGrouped.php
@@ -7,50 +7,18 @@
 
 namespace Emico\TweakwiseExport\Model\Write\Products;
 
-use Emico\TweakwiseExport\Model\StockItem;
+use Emico\TweakwiseExport\Traits\Stock\HasStockThroughChildren;
 
+/**
+ * Class ExportEntityGrouped
+ * @package Emico\TweakwiseExport\Model\Write\Products
+ */
 class ExportEntityGrouped extends CompositeExportEntity
 {
+    use HasStockThroughChildren;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $isStockCombined;
-
-    /**
-     * @return StockItem
-     */
-    public function getStockItem(): ?StockItem
-    {
-        if ($this->isStockCombined) {
-            return $this->stockItem;
-        }
-
-        if (!$this->children) {
-            return $this->stockItem;
-        }
-
-        $childQty = [];
-        $childStockStatus = [];
-
-        foreach ($this->getEnabledChildren() as $child) {
-            $childQty[] = $child->getStockItem()->getQty();
-            $childStockStatus[] = $child->getStockItem()->getIsInStock();
-        }
-
-        if (empty($childStockStatus) || empty($childQty)) {
-            $this->isStockCombined = true;
-            return $this->stockItem;
-        }
-
-        $qty = (int) max($childQty);
-        $isInStock = min(max($childStockStatus), $this->stockItem->getIsInStock());
-        $stockItem = new StockItem();
-        $stockItem->setQty($qty);
-        $stockItem->setIsInStock($isInStock);
-
-        $this->stockItem = $stockItem;
-        $this->isStockCombined = true;
-        return $this->stockItem;
-    }
 }

--- a/Traits/Stock/HasStockThroughChildren.php
+++ b/Traits/Stock/HasStockThroughChildren.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @author : Herant Awadisan, email: hawadisan@emico.nl.
+ * @copyright : Copyright Emico B.V. 2021.
+ */
+
+namespace Emico\TweakwiseExport\Traits\Stock;
+
+use Emico\TweakwiseExport\Model\StockItem;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+
+/**
+ * Trait HasChildren
+ * @package Emico\TweakwiseExport\Traits
+ */
+trait HasStockThroughChildren
+{
+    /**
+     * @return StockItem
+     */
+    public function getStockItem(): ?StockItem
+    {
+        if ($this->isStockCombined) {
+            return $this->stockItem;
+        }
+
+        if (!$this->children) {
+            return $this->stockItem;
+        }
+
+        $childQty = [];
+        $childStockStatus = [];
+
+        foreach ($this->getEnabledChildren() as $child) {
+            $childQty[] = $child->getStockItem()->getQty();
+            $childStockStatus[] = $child->getStockItem()->getIsInStock();
+        }
+
+        if (empty($childStockStatus) || empty($childQty)) {
+            $this->isStockCombined = true;
+            return $this->stockItem;
+        }
+
+        $qty = (int) array_sum($childQty);
+        $isInStock = min(
+            max($childStockStatus),
+            $this->getTypeId() === Configurable::TYPE_CODE ? 1 : $this->stockItem->getIsInStockk()
+        );
+        $stockItem = new StockItem();
+        $stockItem->setQty($qty);
+        $stockItem->setIsInStock($isInStock);
+
+        $this->stockItem = $stockItem;
+        $this->isStockCombined = true;
+        return $this->stockItem;
+    }
+}


### PR DESCRIPTION
Make configurable products always have stock if at least one of the children has stock (configurables don't have inventory source items). Also add trait for removing duplicate code