### PR TITLE
Making Categories and Products writers more extensible

### DIFF
--- a/Model/Write/Categories.php
+++ b/Model/Write/Categories.php
@@ -101,8 +101,9 @@ class Categories implements WriterInterface
      * @param Writer $writer
      * @param XMLWriter $xml
      * @param Store $store
+     * @param int[] $entityIds
      */
-    protected function exportStore(Writer $writer, XMLWriter $xml, Store $store): void
+    public function exportStore(Writer $writer, XMLWriter $xml, Store $store, array $entityIds = []): void
     {
         // Set root category as exported
         $exportedCategories = [1 => true];
@@ -110,7 +111,7 @@ class Categories implements WriterInterface
         $storeRootCategoryId = (int) $store->getRootCategoryId();
         $this->iterator->setStore($store);
         // Purge iterator entity ids for the new store
-        $this->iterator->setEntityIds([]);
+        $this->iterator->setEntityIds($entityIds);
 
         foreach ($this->iterator as $index => $data) {
             // Skip magento root since we injected our fake root

--- a/Model/Write/Products.php
+++ b/Model/Write/Products.php
@@ -117,12 +117,13 @@ class Products implements WriterInterface
      * @param Writer $writer
      * @param XMLWriter $xml
      * @param Store $store
+     * @param int[] $entityIds
      */
-    protected function exportStore(Writer $writer, XMLWriter $xml, Store $store): void
+    public function exportStore(Writer $writer, XMLWriter $xml, Store $store, array $entityIds = []): void
     {
         $this->iterator->setStore($store);
         // Purge iterator entity ids for each store
-        $this->iterator->setEntityIds([]);
+        $this->iterator->setEntityIds($entityIds);
 
         foreach ($this->iterator as $index => $data) {
             $this->writeProduct($xml, $store->getId(), $data);


### PR DESCRIPTION
Recently I was coding a customization for tweakwise in a client which I work for and I came to realize that it's kind hard to edit the IDs that tweakwise decides to export.

Making the exportStore method public and passing IDs as parameters developers can create before plugins to intercept which IDs they want to export.