### PR TITLE
Use a separate cron group for the export task

### DIFF
--- a/etc/cron_groups.xml
+++ b/etc/cron_groups.xml
@@ -1,0 +1,11 @@
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/cron_groups.xsd">
+    <group id="emico_tweakwise">
+        <schedule_generate_every>60</schedule_generate_every>
+        <schedule_ahead_for>20</schedule_ahead_for>
+        <schedule_lifetime>1440</schedule_lifetime>
+        <history_cleanup_every>2880</history_cleanup_every>
+        <history_success_lifetime>2880</history_success_lifetime>
+        <history_failure_lifetime>2880</history_failure_lifetime>
+        <use_separate_process>1</use_separate_process>
+    </group>
+</config>

--- a/etc/cron_groups.xml
+++ b/etc/cron_groups.xml
@@ -1,7 +1,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/cron_groups.xsd">
     <group id="emico_tweakwise">
-        <schedule_generate_every>60</schedule_generate_every>
-        <schedule_ahead_for>20</schedule_ahead_for>
+        <schedule_generate_every>30</schedule_generate_every>
+        <schedule_ahead_for>60</schedule_ahead_for>
         <schedule_lifetime>1440</schedule_lifetime>
         <history_cleanup_every>2880</history_cleanup_every>
         <history_success_lifetime>2880</history_success_lifetime>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -8,7 +8,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
-    <group id="default">
+    <group id="emico_tweakwise">
         <job name="emico_tweakwise_export" instance="Emico\TweakwiseExport\Cron\Export" method="execute">
             <config_path>tweakwise/export/schedule</config_path>
         </job>


### PR DESCRIPTION
Use a separate cron group for the export task, so it can be configured to not block other cron tasks

We are maintaining a very large webshop (~300k products).
The export to tweakwise can take well over an hour, sometimes closer to two.

If the cron task runs in it's own group it can run on a separate cron process, so it does not interfere with other magento cron tasks.