### PR TITLE
Type cast data value to integer

### DIFF
--- a/Model/Write/Categories.php
+++ b/Model/Write/Categories.php
@@ -133,7 +133,7 @@ class Categories implements WriterInterface
             // Always export store root category whether it is enabled or not
             if ($parentId === 1) {
                 // Skip category if not root of current store
-                if ($data['entity_id'] !== $storeRootCategoryId) {
+                if ((int) $data['entity_id'] !== $storeRootCategoryId) {
                     continue;
                 }
 


### PR DESCRIPTION
Type cast data value to integer to make sure comparison is always between two integers. Because `$storeRootCategoryId` is type casted to int on line 120.